### PR TITLE
remove monaco from the font family

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -5,7 +5,7 @@
 
 // Our variables
 $base-font-family: Bitter, "Apple SD Gothic Neo", AppleGothic, NanumBarunGothic, "Malgun Gothic", Dotum, sans-serif;
-$monospace-font-family: Monaco, Menlo, Consolas, "Courier New", DotumChe, monospace;
+$monospace-font-family: Menlo, Consolas, "Courier New", DotumChe, monospace;
 $base-font-size:   16px;
 $base-font-weight: 400;
 $small-font-size:  $base-font-size * 0.875;


### PR DESCRIPTION
Monaco bold looks wrong on Safari MacOS in a 1x resolution monitor:

![Screenshot 2025-01-13 at 13 58 47](https://github.com/user-attachments/assets/566879cf-7b77-445e-bc36-b3437e8d2c92)

removing it from the font family makes `menlo` the next choice which looks fine in bold:
![Screenshot 2025-01-13 at 14 00 10](https://github.com/user-attachments/assets/386459c1-675e-4c9c-b58f-134c5fdd1518)
